### PR TITLE
[Certora] Handle overflows

### DIFF
--- a/certora/README.md
+++ b/certora/README.md
@@ -51,7 +51,7 @@ The [`certora/specs`](specs) folder contains the following files:
 - [`ExternalCalls.spec`](specs/ExternalCalls.spec) checks that the Morpho token implementation is reentrancy safe by ensuring that no function is making and external calls and, that the implementation is immutable as it doesn't perform any delegate call;
 - [`ERC20Invariants.spec`](specs/ERC20Invariants.spec) common hooks and invariants to be shared in different specs;
 - [`ERC20.spec`](specs/ERC20.spec) ensures that the Morpho token is compliant with the [ERC20](https://eips.ethereum.org/EIPS/eip-20) specification, we also check Morpho token `burn` and `mint` functions in [`MintBurnEthereum`](specs/MintBurnEthereum.spec) and [`MintBurnOptimism`](specs/MintBurnOptimism.spec);
-- [`Delegation.spec`](specs/Delegation.spec) checks the logic for voting power delegation.
+- [`Delegation.spec`](specs/Delegation.spec) checks the logic for voting power delegation;
 - [`RevertsERC20.spec`](specs/RevertsERC20.spec), [`RevertsMintBurnEthereum.spec`](specs/RevertsMintBurnEthereum.spec) and [`RevertsMintBurnOptimism.spec`](specs/RevertsMintBurnOptimism.spec) check that conditions for reverts and inputs are correctly validated.
 
 The [`certora/confs`](confs) folder contains a configuration file for each corresponding specification file for both the Ethereum and the Optimism version.

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -159,7 +159,6 @@ invariant sumOfTwoDelegatedVPLTEqTotalVP()
         }
     }
 
-
 function isTotalSupplyGTEqSumOfVotingPower() returns bool {
     requireInvariant totalSupplyIsSumOfVirtualVotingPower();
     return totalSupply() >= sumOfVotes[2^160];
@@ -214,4 +213,34 @@ rule delegatingWithSigUpdatesVotingPower(env e, DelegationToken.Delegation deleg
     } else {
         assert delegatedVotingPower(delegation.delegatee) == delegatedVotingPowerBefore + balanceOf(delegator);
     }
+}
+
+// Check that the delegated voting power of a delegatee after an update is lesser than or equal to the total supply of tokens.
+rule updatedDelegatedVPLTEqTotalSupply(env e, address to, uint256 amount) {
+    // Safe require as implementation woud revert.
+    require amount <= balanceOf(e.msg.sender);
+
+    // Safe rquire as zero address can't initiate transactions.
+    require e.msg.sender != 0;
+
+    // Safe require as since we consider only updates.
+    require delegatee(to) != delegatee(e.msg.sender);
+
+    delegate(e, e.msg.sender);
+
+    assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
+
+    // Safe require that follows from delegatedLTEqDelegateeVP.
+    require amount <= delegatedVotingPower(e.msg.sender) ;
+
+    requireInvariant delegatedVotingPowerLTEqTotalVotingPower();
+    requireInvariant sumOfVotesStartsAtZero();
+    requireInvariant sumOfVotesGrowsCorrectly();
+    requireInvariant sumOfVotesMonotone();
+    requireInvariant totalSupplyIsSumOfVirtualVotingPower();
+    requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
+
+    assert isTotalSupplyGTEqSumOfVotingPower();
+
+    assert delegatedVotingPower(to) + amount <=  totalSupply();
 }

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -227,21 +227,24 @@ rule updatedDelegatedVPLTEqTotalSupply(env e, address to, uint256 amount) {
     require delegatee(to) != delegatee(e.msg.sender);
 
     delegate@withrevert(e, e.msg.sender);
-    bool reverted = lastReverted;
+    if (!lastReverted) {
+           assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
 
-    assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
+           // Safe require that follows from delegatedLTEqDelegateeVP.
+           require amount <= delegatedVotingPower(e.msg.sender) ;
 
-    // Safe require that follows from delegatedLTEqDelegateeVP.
-    require amount <= delegatedVotingPower(e.msg.sender) ;
+           requireInvariant delegatedVotingPowerLTEqTotalVotingPower();
+           requireInvariant sumOfVotesStartsAtZero();
+           requireInvariant sumOfVotesGrowsCorrectly();
+           requireInvariant sumOfVotesMonotone();
+           requireInvariant totalSupplyIsSumOfVirtualVotingPower();
+           requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
 
-    requireInvariant delegatedVotingPowerLTEqTotalVotingPower();
-    requireInvariant sumOfVotesStartsAtZero();
-    requireInvariant sumOfVotesGrowsCorrectly();
-    requireInvariant sumOfVotesMonotone();
-    requireInvariant totalSupplyIsSumOfVirtualVotingPower();
-    requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
+           assert isTotalSupplyGTEqSumOfVotingPower();
 
-    assert isTotalSupplyGTEqSumOfVotingPower();
-
-    assert !reverted => delegatedVotingPower(to) + amount <=  totalSupply();
+           assert delegatedVotingPower(to) + amount <=  totalSupply();
+       } else {
+           // Do not check anything
+           assert true;
+       }
 }

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -217,34 +217,27 @@ rule delegatingWithSigUpdatesVotingPower(env e, DelegationToken.Delegation deleg
 
 // Check that the updated voting power of a delegatee after a transfer is lesser than or equal to the total supply of tokens.
 rule updatedDelegatedVPLTEqTotalSupply(env e, address to, uint256 amount) {
-    // Safe require as the ERC20 implementation woud revert.
-    require amount <= balanceOf(e.msg.sender);
-
-    // Safe require as zero address can't initiate transactions.
-    require e.msg.sender != 0;
-    // Safe require as transfers are non-payable functions.
     require e.msg.value == 0;
+    require e.msg.sender != 0;
 
-    // Safe require as since we consider only updates.
+    require amount <= balanceOf(e.msg.sender);
     require delegatee(to) != delegatee(e.msg.sender);
 
     requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
     assert isTotalSupplyGTEqSumOfVotingPower();
 
-    // Safe require as zeroVirtualVotingPower accounts for the delegated votes to address zero.
+    // This require avoids an impossible revert as zeroVirtualVotingPower operations comme from munging.
     require delegatee(e.msg.sender) == 0 => currentContract._zeroVirtualVotingPower >= balanceOf(e.msg.sender);
 
-    // Safe require as it is proven by delegatedLTEqDelegateeVP.
-    // The invariant itself can't be required as it's using a parameterized variable.
+    // This invariant can't be required as it's using a parameterized variable.
+    // But it is proven by delegatedLTEqDelegateeVP.
     require delegatee(e.msg.sender) != 0 => delegatedVotingPower(delegatee(e.msg.sender)) >= balanceOf(e.msg.sender);
 
     delegate@withrevert(e, e.msg.sender);
+
     assert(!lastReverted);
 
-    assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
-
-    // Safe require that follows from delegatedLTEqDelegateeVP.
-    require amount <= delegatedVotingPower(e.msg.sender) ;
+    assert delegatee(e.msg.sender) == e.msg.sender;
 
     assert delegatedVotingPower(to) + amount <=  totalSupply();
 }

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -221,7 +221,7 @@ rule updatedDelegatedVPLTEqTotalSupply(address from, address to) {
     assert isTotalSupplyGTEqSumOfVotingPower();
 
     // Safe require as _zeroVirtualVotingPower is the (virtual) voting power of address zero.
-    require delegatee(from) == 0 => currentContract._zeroVirtualVotingPower >=  balanceOf(from);
+    require delegatee(from) == 0 => currentContract._zeroVirtualVotingPower >= balanceOf(from);
 
     // Safe require as it is proven in delegatedLTEqDelegateeVP.
     require delegatee(from) != 0 => delegatedVotingPower(delegatee(from)) >= balanceOf(from);

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -220,7 +220,6 @@ rule updatedDelegatedVPLTEqTotalSupply(address from, address to) {
     uint256 balanceOfFromBefore = balanceOf(from);
     uint256 delegatedVotingPowerDelegateeToBefore = delegatedVotingPower(delegatee(to));
     uint256 totalSupplyBefore = totalSupply();
-    env e;
 
     requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
     assert isTotalSupplyGTEqSumOfVotingPower();
@@ -235,6 +234,7 @@ rule updatedDelegatedVPLTEqTotalSupply(address from, address to) {
 
     require delegatee(from) != 0 => delegatedVotingPower(delegatee(from)) >= balanceOfFromBefore;
 
+    env e;
     // Safe require-statements to perform a ghost call to delegate(from).
     require e.msg.value == 0;
     require e.msg.sender == from;

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -229,6 +229,8 @@ rule updatedDelegatedVPLTEqTotalSupply(env e, address to, uint256 amount) {
     // This require avoids an impossible revert as zeroVirtualVotingPower operations comme from munging.
     require delegatee(e.msg.sender) == 0 => currentContract._zeroVirtualVotingPower >= balanceOf(e.msg.sender);
 
+    uint256 delegatedVotingPowerDelegateeToBefore = delegatedVotingPower(delegatee(to));
+
     // This invariant can't be required as it's using a parameterized variable.
     // But it is proven by delegatedLTEqDelegateeVP.
     require delegatee(e.msg.sender) != 0 => delegatedVotingPower(delegatee(e.msg.sender)) >= balanceOf(e.msg.sender);
@@ -239,5 +241,5 @@ rule updatedDelegatedVPLTEqTotalSupply(env e, address to, uint256 amount) {
 
     assert delegatee(e.msg.sender) == e.msg.sender;
 
-    assert delegatedVotingPower(to) + amount <=  totalSupply();
+    assert delegatedVotingPowerDelegateeToBefore + amount <=  totalSupply();
 }

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -224,12 +224,12 @@ rule updatedDelegatedVPLTEqTotalSupply(address from, address to) {
     requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
     assert isTotalSupplyGTEqSumOfVotingPower();
 
-    // Safe require-statements that introduce the premises of the goal formula, from != 0 => delegatee(to) != delegatee(from) => delegatedVotingPower(delegateee(to)) + balanceOf(from) <= totalSupply().
+    // Safe require-statements that introduce the premises of the goal formula, from != 0 => delegatee(to) != delegatee(from) => delegatedVotingPower(delegatee(to)) + balanceOf(from) <= totalSupply().
     require from != 0;
     require delegatee(to) != delegatee(from);
 
 
-    // This require avoids an impossible revert as zeroVirtualVotingPower operations comme from munging.
+    // This require avoids an impossible revert as zeroVirtualVotingPower operations come from munging.
     require delegatee(from) == 0 => currentContract._zeroVirtualVotingPower >=  balanceOfFromBefore;
 
     require delegatee(from) != 0 => delegatedVotingPower(delegatee(from)) >= balanceOfFromBefore;

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -215,36 +215,37 @@ rule delegatingWithSigUpdatesVotingPower(env e, DelegationToken.Delegation deleg
     }
 }
 
-// Check that the delegated voting power of a delegatee after an update is lesser than or equal to the total supply of tokens.
+// Check that the delegated voting power of a delegatee after a transfer is lesser than or equal to the total supply of tokens.
 rule updatedDelegatedVPLTEqTotalSupply(env e, address to, uint256 amount) {
-    // Safe require as implementation woud revert.
+    // Safe require as the ERC20 implementation woud revert.
     require amount <= balanceOf(e.msg.sender);
 
-    // Safe rquire as zero address can't initiate transactions.
+    // Safe require as zero address can't initiate transactions.
     require e.msg.sender != 0;
 
     // Safe require as since we consider only updates.
     require delegatee(to) != delegatee(e.msg.sender);
 
     delegate@withrevert(e, e.msg.sender);
-    if (!lastReverted) {
-           assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
 
-           // Safe require that follows from delegatedLTEqDelegateeVP.
-           require amount <= delegatedVotingPower(e.msg.sender) ;
+    // Show that delegate doesn't always revert.
+    bool reverted = lastReverted;
+    satisfy !reverted;
+    require !reverted;
 
-           requireInvariant delegatedVotingPowerLTEqTotalVotingPower();
-           requireInvariant sumOfVotesStartsAtZero();
-           requireInvariant sumOfVotesGrowsCorrectly();
-           requireInvariant sumOfVotesMonotone();
-           requireInvariant totalSupplyIsSumOfVirtualVotingPower();
-           requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
+    assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
 
-           assert isTotalSupplyGTEqSumOfVotingPower();
+    // Safe require that follows from delegatedLTEqDelegateeVP.
+    require amount <= delegatedVotingPower(e.msg.sender) ;
 
-           assert delegatedVotingPower(to) + amount <=  totalSupply();
-       } else {
-           // Do not check anything
-           assert true;
-       }
+    requireInvariant delegatedVotingPowerLTEqTotalVotingPower();
+    requireInvariant sumOfVotesStartsAtZero();
+    requireInvariant sumOfVotesGrowsCorrectly();
+    requireInvariant sumOfVotesMonotone();
+    requireInvariant totalSupplyIsSumOfVirtualVotingPower();
+    requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
+
+    assert isTotalSupplyGTEqSumOfVotingPower();
+
+    assert delegatedVotingPower(to) + amount <=  totalSupply();
 }

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -226,21 +226,24 @@ rule updatedDelegatedVPLTEqTotalSupply(env e, address to, uint256 amount) {
     // Safe require as since we consider only updates.
     require delegatee(to) != delegatee(e.msg.sender);
 
-    delegate(e, e.msg.sender);
+    delegate@withrevert(e, e.msg.sender);
 
-    assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
+    if (!lastReverted) {
 
-    // Safe require that follows from delegatedLTEqDelegateeVP.
-    require amount <= delegatedVotingPower(e.msg.sender) ;
+        assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
 
-    requireInvariant delegatedVotingPowerLTEqTotalVotingPower();
-    requireInvariant sumOfVotesStartsAtZero();
-    requireInvariant sumOfVotesGrowsCorrectly();
-    requireInvariant sumOfVotesMonotone();
-    requireInvariant totalSupplyIsSumOfVirtualVotingPower();
-    requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
+        // Safe require that follows from delegatedLTEqDelegateeVP.
+        require amount <= delegatedVotingPower(e.msg.sender) ;
 
-    assert isTotalSupplyGTEqSumOfVotingPower();
+        requireInvariant delegatedVotingPowerLTEqTotalVotingPower();
+        requireInvariant sumOfVotesStartsAtZero();
+        requireInvariant sumOfVotesGrowsCorrectly();
+        requireInvariant sumOfVotesMonotone();
+        requireInvariant totalSupplyIsSumOfVirtualVotingPower();
+        requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
 
-    assert delegatedVotingPower(to) + amount <=  totalSupply();
+        assert isTotalSupplyGTEqSumOfVotingPower();
+
+        assert delegatedVotingPower(to) + amount <=  totalSupply();
+    }
 }

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -227,23 +227,21 @@ rule updatedDelegatedVPLTEqTotalSupply(env e, address to, uint256 amount) {
     require delegatee(to) != delegatee(e.msg.sender);
 
     delegate@withrevert(e, e.msg.sender);
+    bool reverted = lastReverted;
 
-    if (!lastReverted) {
+    assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
 
-        assert delegatee(e.msg.sender) == e.msg.sender && delegatee(e.msg.sender) != 0;
+    // Safe require that follows from delegatedLTEqDelegateeVP.
+    require amount <= delegatedVotingPower(e.msg.sender) ;
 
-        // Safe require that follows from delegatedLTEqDelegateeVP.
-        require amount <= delegatedVotingPower(e.msg.sender) ;
+    requireInvariant delegatedVotingPowerLTEqTotalVotingPower();
+    requireInvariant sumOfVotesStartsAtZero();
+    requireInvariant sumOfVotesGrowsCorrectly();
+    requireInvariant sumOfVotesMonotone();
+    requireInvariant totalSupplyIsSumOfVirtualVotingPower();
+    requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
 
-        requireInvariant delegatedVotingPowerLTEqTotalVotingPower();
-        requireInvariant sumOfVotesStartsAtZero();
-        requireInvariant sumOfVotesGrowsCorrectly();
-        requireInvariant sumOfVotesMonotone();
-        requireInvariant totalSupplyIsSumOfVirtualVotingPower();
-        requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
+    assert isTotalSupplyGTEqSumOfVotingPower();
 
-        assert isTotalSupplyGTEqSumOfVotingPower();
-
-        assert delegatedVotingPower(to) + amount <=  totalSupply();
-    }
+    assert !reverted => delegatedVotingPower(to) + amount <=  totalSupply();
 }

--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -216,28 +216,28 @@ rule delegatingWithSigUpdatesVotingPower(env e, DelegationToken.Delegation deleg
 }
 
 // Check that the updated voting power of a delegatee after a transfer is lesser than or equal to the total supply of tokens.
-rule updatedDelegatedVPLTEqTotalSupply(address from, address to, uint256 amount) {
-    require from != 0;
-
+rule updatedDelegatedVPLTEqTotalSupply(address from, address to) {
+    uint256 balanceOfFromBefore = balanceOf(from);
+    uint256 delegatedVotingPowerDelegateeToBefore = delegatedVotingPower(delegatee(to));
+    uint256 totalSupplyBefore = totalSupply();
     env e;
+
     require e.msg.value == 0;
     require e.msg.sender == from;
 
-    require amount <= balanceOf(from);
+    require from != 0;
     require delegatee(to) != delegatee(from);
 
     requireInvariant sumOfTwoDelegatedVPLTEqTotalVP();
     assert isTotalSupplyGTEqSumOfVotingPower();
 
     // This require avoids an impossible revert as zeroVirtualVotingPower operations comme from munging.
-    require delegatee(from) == 0 => currentContract._zeroVirtualVotingPower >= balanceOf(from);
+    require delegatee(from) == 0 => currentContract._zeroVirtualVotingPower >=  balanceOfFromBefore;
 
-    uint256 delegatedVotingPowerDelegateeToBefore = delegatedVotingPower(delegatee(to));
-    uint256 totalSupplyBefore = totalSupply();
 
     // This invariant can't be required as it's using a parameterized variable.
     // But it is proven by delegatedLTEqDelegateeVP.
-    require delegatee(from) != 0 => delegatedVotingPower(delegatee(from)) >= balanceOf(from);
+    require delegatee(from) != 0 => delegatedVotingPower(delegatee(from)) >= balanceOfFromBefore;
 
     delegate@withrevert(e, from);
 
@@ -245,5 +245,5 @@ rule updatedDelegatedVPLTEqTotalSupply(address from, address to, uint256 amount)
 
     assert delegatee(from) == from;
 
-    assert delegatedVotingPowerDelegateeToBefore + amount <= totalSupplyBefore;
+    assert delegatedVotingPowerDelegateeToBefore + balanceOfFromBefore <= totalSupplyBefore;
 }

--- a/certora/specs/ERC20.spec
+++ b/certora/specs/ERC20.spec
@@ -87,14 +87,17 @@ rule transfer(env e) {
     uint256 recipientVotingPowerBefore = delegatedVotingPower(delegatee(recipient));
     uint256 otherBalanceBefore     = balanceOf(other);
 
+    // Safe require as it is verified in delegatedLTEqDelegateeVP.
+    require holderBalanceBefore <= holderVotingPowerBefore;
+    // Safe require as it is verified in totalSupplyGTEqSumOfVotingPower.
+    require delegatee(holder) != delegatee(recipient) => holderBalanceBefore + recipientVotingPowerBefore <= totalSupply();
+
     // run transaction
     transfer@withrevert(e, recipient, amount);
 
     // check outcome
     if (lastReverted) {
-        assert holder == 0 || recipient == 0 || amount > holderBalanceBefore ||
-            // Handle overflows in delegation, should not be possible.
-            recipientVotingPowerBefore + amount > max_uint256 || holderVotingPowerBefore < amount ;
+        assert holder == 0 || recipient == 0 || amount > holderBalanceBefore;
     } else {
         // balances of holder and recipient are updated
         assert to_mathint(balanceOf(holder))    == holderBalanceBefore    - (holder == recipient ? 0 : amount);
@@ -129,14 +132,17 @@ rule transferFrom(env e) {
     uint256 recipientVotingPowerBefore = delegatedVotingPower(delegatee(recipient));
     uint256 otherBalanceBefore     = balanceOf(other);
 
+    // Safe require as it is verified in delegatedLTEqDelegateeVP.
+    require holderBalanceBefore <= holderVotingPowerBefore;
+    // Safe require as it is verified in totalSupplyGTEqSumOfVotingPower.
+    require delegatee(holder) != delegatee(recipient) => holderBalanceBefore + recipientVotingPowerBefore <= totalSupply();
+
     // run transaction
     transferFrom@withrevert(e, holder, recipient, amount);
 
     // check outcome
     if (lastReverted) {
-        assert holder == 0 || recipient == 0 || spender == 0 || amount > holderBalanceBefore || amount > allowanceBefore
-            // Handle overflows in delegation, should not be possible.
-            ||  amount + recipientVotingPowerBefore > max_uint256 || holderVotingPowerBefore < amount ;
+        assert holder == 0 || recipient == 0 || spender == 0 || amount > holderBalanceBefore || amount > allowanceBefore;
     } else {
         // allowance is valid & updated
         assert allowanceBefore            >= amount;

--- a/certora/specs/ERC20.spec
+++ b/certora/specs/ERC20.spec
@@ -88,9 +88,9 @@ rule transfer(env e) {
     uint256 otherBalanceBefore     = balanceOf(other);
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
-    require holderBalanceBefore <= holderVotingPowerBefore;
+    require delegatee(holder) != 0 => holderBalanceBefore <= holderVotingPowerBefore;
     // Safe require as it is verified in totalSupplyGTEqSumOfVotingPower.
-    require delegatee(holder) != delegatee(recipient) => holderBalanceBefore + recipientVotingPowerBefore <= totalSupply();
+    require delegatee(holder) != delegatee(recipient) => recipientVotingPowerBefore + holderBalanceBefore <= totalSupply();
 
     // run transaction
     transfer@withrevert(e, recipient, amount);
@@ -133,9 +133,9 @@ rule transferFrom(env e) {
     uint256 otherBalanceBefore     = balanceOf(other);
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
-    require holderBalanceBefore <= holderVotingPowerBefore;
+    require delegatee(holder) != 0 => holderBalanceBefore <= holderVotingPowerBefore;
     // Safe require as it is verified in totalSupplyGTEqSumOfVotingPower.
-    require delegatee(holder) != delegatee(recipient) => holderBalanceBefore + recipientVotingPowerBefore <= totalSupply();
+    require delegatee(holder) != delegatee(recipient) => recipientVotingPowerBefore + holderBalanceBefore <= totalSupply();
 
     // run transaction
     transferFrom@withrevert(e, holder, recipient, amount);

--- a/certora/specs/MintBurnEthereum.spec
+++ b/certora/specs/MintBurnEthereum.spec
@@ -67,7 +67,6 @@ rule mint(env e) {
 
     // cache state
     uint256 toBalanceBefore    = balanceOf(to);
-    uint256 toVotingPowerBefore = delegatedVotingPower(delegatee(to));
     uint256 otherBalanceBefore = balanceOf(other);
     uint256 totalSupplyBefore  = totalSupply();
 
@@ -76,8 +75,7 @@ rule mint(env e) {
 
     // check outcome
     if (lastReverted) {
-        assert e.msg.sender != owner() || to == 0 || totalSupplyBefore + amount > max_uint256 ||
-            toVotingPowerBefore + amount > max_uint256;
+        assert e.msg.sender != owner() || to == 0 || totalSupplyBefore + amount > max_uint256 ;
     } else {
         // updates balance and totalSupply
         assert e.msg.sender == owner();

--- a/certora/specs/MintBurnEthereum.spec
+++ b/certora/specs/MintBurnEthereum.spec
@@ -110,12 +110,17 @@ rule burn(env e) {
     uint256 otherBalanceBefore = balanceOf(other);
     uint256 totalSupplyBefore  = totalSupply();
 
+    // Safe require as zeroVirtualVotingPower represents the virtual sum of votes delegated to zero.
+    require delegatee(from) == 0 => fromBalanceBefore <= currentContract._zeroVirtualVotingPower;
+    // Safe require as it is verified in delegatedLTEqDelegateeVP.
+    require delegatee(from) != 0 => fromBalanceBefore <= fromVotingPowerBefore;
+
     // run transaction
     burn@withrevert(e, amount);
 
     // check outcome
     if (lastReverted) {
-        assert e.msg.sender == 0x0 ||  fromBalanceBefore < amount || fromVotingPowerBefore < amount ;
+        assert e.msg.sender == 0x0 || fromBalanceBefore < amount;
     } else {
         // updates balance and totalSupply
         assert to_mathint(balanceOf(from)) == fromBalanceBefore - amount;

--- a/certora/specs/MintBurnOptimism.spec
+++ b/certora/specs/MintBurnOptimism.spec
@@ -68,7 +68,6 @@ rule mint(env e) {
 
     // cache state
     uint256 toBalanceBefore    = balanceOf(to);
-    uint256 toVotingPowerBefore = delegatedVotingPower(delegatee(to));
     uint256 otherBalanceBefore = balanceOf(other);
     uint256 totalSupplyBefore  = totalSupply();
 
@@ -78,7 +77,7 @@ rule mint(env e) {
     // check outcome
     if (lastReverted) {
         assert e.msg.sender != owner() || to == 0 || totalSupplyBefore + amount > max_uint256 ||
-            toVotingPowerBefore + amount > max_uint256 || e.msg.sender != currentContract.bridge;
+            e.msg.sender != currentContract.bridge;
     } else {
         // updates balance and totalSupply
         assert e.msg.sender == currentContract.bridge;

--- a/certora/specs/MintBurnOptimism.spec
+++ b/certora/specs/MintBurnOptimism.spec
@@ -112,13 +112,17 @@ rule burn(env e) {
     uint256 otherBalanceBefore = balanceOf(other);
     uint256 totalSupplyBefore  = totalSupply();
 
+    // Safe require as zeroVirtualVotingPower represents the virtual sum of votes delegated to zero.
+    require delegatee(from) == 0 => fromBalanceBefore <= currentContract._zeroVirtualVotingPower;
+    // Safe require as it is verified in delegatedLTEqDelegateeVP.
+    require delegatee(from) != 0 => fromBalanceBefore <= fromVotingPowerBefore;
+
     // run transaction
     burn@withrevert(e, from,  amount);
 
     // check outcome
     if (lastReverted) {
-           assert e.msg.sender == 0x0 || fromBalanceBefore < amount || fromVotingPowerBefore < amount
-               || e.msg.sender != currentContract.bridge;
+        assert e.msg.sender == 0x0 || fromBalanceBefore < amount || e.msg.sender != currentContract.bridge;
     } else {
         // updates balance and totalSupply
         assert to_mathint(balanceOf(from)) == fromBalanceBefore - amount;

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -21,7 +21,7 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
-      e.msg.sender != 0 => e.msg.value == 0 =>
+      e.msg.sender != 0 =>
       amount <= balanceOfSenderBefore =>
       delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + amount <= totalSupply();
 
@@ -43,7 +43,7 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
-      from != 0 => e.msg.value == 0 =>
+      from != 0 =>
       amount <= balanceOfHolderBefore =>
       delegatee(to) != delegatee(from) => recipientVotingPowerBefore + amount <= totalSupply();
 

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -15,9 +15,10 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
     uint256 recipientVotingPowerBefore = delegatedVotingPower(delegatee(to));
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
-    require senderVotingPowerBefore >= balanceOfSenderBefore;
-    // Safe require that follows from sumOfTwoDelegatedVPLTEqTotalVP() and totalSupplyIsSumOfVirtualVotingPower().
-    require delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + senderVotingPowerBefore <= totalSupply();
+    require delegatee(e.msg.sender) != 0 => senderVotingPowerBefore >= balanceOfSenderBefore;
+
+    // Safe require that follows from sumOfTwoDelegatedVPLTEqTotalVP() and totalSupplyIsSumOfVirtualVotingPower() and rule updatedDelegatedVPLTEqTotalSupply.
+    require delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + amount <= totalSupply();
 
     transfer@withrevert(e, to, amount);
     assert lastReverted <=> e.msg.sender == 0 || to == 0 || balanceOfSenderBefore < amount || e.msg.value != 0;
@@ -31,9 +32,9 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
     uint256 recipientVotingPowerBefore = delegatedVotingPower(delegatee(to));
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
-    require holderVotingPowerBefore >= balanceOfHolderBefore;
-    // Safe require that follows from sumOfTwoDelegatedVPLTEqTotalVP() and totalSupplyIsSumOfVirtualVotingPower().
-    require delegatee(to) != delegatee(from) => recipientVotingPowerBefore + holderVotingPowerBefore <= totalSupply();
+    require delegatee(from) != 0 => holderVotingPowerBefore >= balanceOfHolderBefore;
+    // Safe require that follows from sumOfTwoDelegatedVPLTEqTotalVP() and totalSupplyIsSumOfVirtualVotingPower() and rule updatedDelegatedVPLTEqTotalSupply
+    require delegatee(to) != delegatee(from) => recipientVotingPowerBefore + amount <= totalSupply();
 
     transferFrom@withrevert(e, from, to, amount);
 

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -18,7 +18,7 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
     require delegatee(e.msg.sender) != 0 => senderVotingPowerBefore >= balanceOfSenderBefore;
 
     // Safe require that follows from sumOfTwoDelegatedVPLTEqTotalVP() and totalSupplyIsSumOfVirtualVotingPower() and rule updatedDelegatedVPLTEqTotalSupply.
-    require delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + amount <= totalSupply();
+    require e.msg.sender != 0 => amount <= balanceOfSenderBefore => delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + amount <= totalSupply();
 
     transfer@withrevert(e, to, amount);
     assert lastReverted <=> e.msg.sender == 0 || to == 0 || balanceOfSenderBefore < amount || e.msg.value != 0;
@@ -34,7 +34,7 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(from) != 0 => holderVotingPowerBefore >= balanceOfHolderBefore;
     // Safe require that follows from sumOfTwoDelegatedVPLTEqTotalVP() and totalSupplyIsSumOfVirtualVotingPower() and rule updatedDelegatedVPLTEqTotalSupply
-    require delegatee(to) != delegatee(from) => recipientVotingPowerBefore + amount <= totalSupply();
+    require from != 0 => amount <= balanceOfHolderBefore => delegatee(to) != delegatee(from) => recipientVotingPowerBefore + amount <= totalSupply();
 
     transferFrom@withrevert(e, from, to, amount);
 

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -16,8 +16,6 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(e.msg.sender) != 0 => senderVotingPowerBefore >= balanceOfSenderBefore;
-    // Safe require as it is verified in sumOfTwoDelegatedVPLTEqTotalVP.
-    require senderVotingPowerBefore + recipientVotingPowerBefore <= totalSupply();
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
@@ -36,8 +34,6 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(from) != 0 => holderVotingPowerBefore >= balanceOfHolderBefore;
-    // Safe require as it is verified in sumOfTwoDelegatedVPLTEqTotalVP.
-    require holderVotingPowerBefore + recipientVotingPowerBefore <= totalSupply();
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -17,7 +17,7 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(e.msg.sender) != 0 => senderVotingPowerBefore >= balanceOfSenderBefore;
 
-    // Safe require that follows from sumOfTwoDelegatedVPLTEqTotalVP() and totalSupplyIsSumOfVirtualVotingPower() and rule updatedDelegatedVPLTEqTotalSupply.
+    // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require e.msg.sender != 0 => amount <= balanceOfSenderBefore => delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + amount <= totalSupply();
 
     transfer@withrevert(e, to, amount);
@@ -33,7 +33,7 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(from) != 0 => holderVotingPowerBefore >= balanceOfHolderBefore;
-    // Safe require that follows from sumOfTwoDelegatedVPLTEqTotalVP() and totalSupplyIsSumOfVirtualVotingPower() and rule updatedDelegatedVPLTEqTotalSupply
+    // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require from != 0 => amount <= balanceOfHolderBefore => delegatee(to) != delegatee(from) => recipientVotingPowerBefore + amount <= totalSupply();
 
     transferFrom@withrevert(e, from, to, amount);

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -21,7 +21,6 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
-      e.msg.sender != 0 =>
       delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + balanceOfSenderBefore <= totalSupply();
 
     transfer@withrevert(e, to, amount);
@@ -42,7 +41,6 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
-      from != 0 =>
       delegatee(to) != delegatee(from) => recipientVotingPowerBefore +  balanceOfHolderBefore <= totalSupply();
 
     transferFrom@withrevert(e, from, to, amount);

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -16,9 +16,14 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(e.msg.sender) != 0 => senderVotingPowerBefore >= balanceOfSenderBefore;
+    // Safe require as it is verified in sumOfTwoDelegatedVPLTEqTotalVP.
+    require senderVotingPowerBefore + recipientVotingPowerBefore <= totalSupply();
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
-    require e.msg.sender != 0 => amount <= balanceOfSenderBefore => delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + amount <= totalSupply();
+    require
+      e.msg.sender != 0 => e.msg.value == 0 =>
+      amount <= balanceOfSenderBefore =>
+      delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + amount <= totalSupply();
 
     transfer@withrevert(e, to, amount);
     assert lastReverted <=> e.msg.sender == 0 || to == 0 || balanceOfSenderBefore < amount || e.msg.value != 0;
@@ -33,15 +38,21 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(from) != 0 => holderVotingPowerBefore >= balanceOfHolderBefore;
+    // Safe require as it is verified in sumOfTwoDelegatedVPLTEqTotalVP.
+    require holderVotingPowerBefore + recipientVotingPowerBefore <= totalSupply();
+
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
-    require from != 0 => amount <= balanceOfHolderBefore => delegatee(to) != delegatee(from) => recipientVotingPowerBefore + amount <= totalSupply();
+    require
+      from != 0 => e.msg.value == 0 =>
+      amount <= balanceOfHolderBefore =>
+      delegatee(to) != delegatee(from) => recipientVotingPowerBefore + amount <= totalSupply();
 
     transferFrom@withrevert(e, from, to, amount);
 
     bool generalRevertConditions = from == 0 || to == 0 || balanceOfHolderBefore < amount || e.msg.value != 0;
 
     if (allowanceOfSenderBefore != max_uint256) {
-        assert lastReverted <=>  e.msg.sender == 0 || allowanceOfSenderBefore < amount || generalRevertConditions;
+        assert lastReverted <=> e.msg.sender == 0 || allowanceOfSenderBefore < amount || generalRevertConditions;
     } else {
         assert lastReverted <=> generalRevertConditions;
     }

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -22,8 +22,7 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
       e.msg.sender != 0 =>
-      amount <= balanceOfSenderBefore =>
-      delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + amount <= totalSupply();
+      delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + balanceOfSenderBefore <= totalSupply();
 
     transfer@withrevert(e, to, amount);
     assert lastReverted <=> e.msg.sender == 0 || to == 0 || balanceOfSenderBefore < amount || e.msg.value != 0;
@@ -44,8 +43,7 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
       from != 0 =>
-      amount <= balanceOfHolderBefore =>
-      delegatee(to) != delegatee(from) => recipientVotingPowerBefore + amount <= totalSupply();
+      delegatee(to) != delegatee(from) => recipientVotingPowerBefore +  balanceOfHolderBefore <= totalSupply();
 
     transferFrom@withrevert(e, from, to, amount);
 

--- a/certora/specs/RevertsMintBurnEthereum.spec
+++ b/certora/specs/RevertsMintBurnEthereum.spec
@@ -33,7 +33,7 @@ rule burnRevertConditions(env e, uint256 amount) {
     require delegatee(0) == 0;
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
-    require delegateeVotingPowerBefore >= balanceOfSenderBefore;
+    require delegatee(e.msg.sender) != 0 => delegateeVotingPowerBefore >= balanceOfSenderBefore;
 
     burn@withrevert(e, amount);
     assert lastReverted <=> e.msg.sender == 0 || balanceOfSenderBefore < amount || e.msg.value != 0;

--- a/certora/specs/RevertsMintBurnOptimism.spec
+++ b/certora/specs/RevertsMintBurnOptimism.spec
@@ -31,7 +31,7 @@ rule burnRevertConditions(env e, address from, uint256 amount) {
     require delegatee(0) == 0;
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
-    require fromVotingPowerBefore >= balanceOfFromBefore;
+    require  delegatee(from) != 0 =>fromVotingPowerBefore >= balanceOfFromBefore;
 
     burn@withrevert(e, from, amount);
     assert lastReverted <=> e.msg.sender != currentContract.bridge || from == 0 || balanceOfFromBefore < amount ||  e.msg.value != 0;


### PR DESCRIPTION
Replace absurd revert conditions with safe requirements that have been proven.
Fixes a very small typo in the `certora/README.md`.
Closes #97.
Fixes #107.