### PR TITLE
[Certora] Remove ghost execution

### DIFF
--- a/certora/specs/Delegation.spec
+++ b/certora/specs/Delegation.spec
@@ -221,7 +221,7 @@ rule updatedDelegatedVPLTEqTotalSupply(address from, address to) {
     assert isTotalSupplyGTEqSumOfVotingPower();
 
     // Safe require as _zeroVirtualVotingPower is the (virtual) voting power of address zero.
-    require delegatee(from) == 0 => currentContract._zeroVirtualVotingPower >=  balanceOf(from);
+    require delegatee(from) == 0 => currentContract._zeroVirtualVotingPower >= balanceOf(from);
 
     // Safe require as it is proven in delegatedLTEqDelegateeVP.
     require delegatee(from) != 0 => delegatedVotingPower(delegatee(from)) >= balanceOf(from);

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -16,8 +16,6 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(e.msg.sender) != 0 => senderVotingPowerBefore >= balanceOfSenderBefore;
-    // Safe require as it is verified in sumOfTwoDelegatedVPLTEqTotalVP.
-    require senderVotingPowerBefore + recipientVotingPowerBefore <= totalSupply();
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
@@ -36,8 +34,6 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(from) != 0 => holderVotingPowerBefore >= balanceOfHolderBefore;
-    // Safe require as it is verified in sumOfTwoDelegatedVPLTEqTotalVP.
-    require holderVotingPowerBefore + recipientVotingPowerBefore <= totalSupply();
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require

--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -21,7 +21,6 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
-      e.msg.sender != 0 =>
       delegatee(to) != delegatee(e.msg.sender) => recipientVotingPowerBefore + balanceOfSenderBefore <= totalSupply();
 
     transfer@withrevert(e, to, amount);
@@ -42,7 +41,6 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
-      from != 0 =>
       delegatee(to) != delegatee(from) => recipientVotingPowerBefore +  balanceOfHolderBefore <= totalSupply();
 
     transferFrom@withrevert(e, from, to, amount);


### PR DESCRIPTION
Note that it also removes one of the assumptions (`from != 0`) of the rule