### PR TITLE
[Certora] Fix sumOfTwoDelegatedVPLTEqTotalVP usage

### DIFF
--- a/certora/specs/RevertsERC20.spec
+++ b/certora/specs/RevertsERC20.spec
@@ -16,8 +16,6 @@ rule transferRevertConditions(env e, address to, uint256 amount) {
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(e.msg.sender) != 0 => senderVotingPowerBefore >= balanceOfSenderBefore;
-    // Safe require as it is verified in sumOfTwoDelegatedVPLTEqTotalVP.
-    require senderVotingPowerBefore + recipientVotingPowerBefore <= totalSupply();
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require
@@ -36,8 +34,6 @@ rule transferFromRevertConditions(env e, address from, address to, uint256 amoun
 
     // Safe require as it is verified in delegatedLTEqDelegateeVP.
     require delegatee(from) != 0 => holderVotingPowerBefore >= balanceOfHolderBefore;
-    // Safe require as it is verified in sumOfTwoDelegatedVPLTEqTotalVP.
-    require holderVotingPowerBefore + recipientVotingPowerBefore <= totalSupply();
 
     // Safe require as it proven in rule updatedDelegatedVPLTEqTotalSupply.
     require


### PR DESCRIPTION
The rule `sumOfTwoDelegatedVPLTEqTotalVP` assumes that the two users are different, which was not a premise of the required formula. Fortunately this required formula can actually be removed